### PR TITLE
[Refactor] CarParkInfoVC 부분을 Combine을 사용하여 뷰 모델로 로직 분리

### DIFF
--- a/CarPark.xcodeproj/project.pbxproj
+++ b/CarPark.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5B0EFB49303BE4CE90804A1B /* Pods_CarPark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6141D3647C40C18A20E4BA25 /* Pods_CarPark.framework */; };
 		6E1241B32A050C7D003247DD /* ParkMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1241B22A050C7D003247DD /* ParkMarker.swift */; };
+		6E569EA72A7A50C800E3E557 /* CarParkInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E569EA62A7A50C800E3E557 /* CarParkInfoViewModel.swift */; };
 		6E64D0652A1491770076C61E /* ViewController+SearchBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0642A1491770076C61E /* ViewController+SearchBarDelegate.swift */; };
 		6E64D0692A149B8B0076C61E /* SearchResultHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0682A149B8B0076C61E /* SearchResultHeaderView.swift */; };
 		6E64D06B2A149CE40076C61E /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D06A2A149CE40076C61E /* NSObject+.swift */; };
@@ -55,6 +56,7 @@
 		0C67B7B6106A8A6AE7673630 /* Pods-CarPark.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CarPark.release.xcconfig"; path = "Target Support Files/Pods-CarPark/Pods-CarPark.release.xcconfig"; sourceTree = "<group>"; };
 		6141D3647C40C18A20E4BA25 /* Pods_CarPark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CarPark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E1241B22A050C7D003247DD /* ParkMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkMarker.swift; sourceTree = "<group>"; };
+		6E569EA62A7A50C800E3E557 /* CarParkInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarParkInfoViewModel.swift; sourceTree = "<group>"; };
 		6E64D0642A1491770076C61E /* ViewController+SearchBarDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+SearchBarDelegate.swift"; sourceTree = "<group>"; };
 		6E64D0682A149B8B0076C61E /* SearchResultHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultHeaderView.swift; sourceTree = "<group>"; };
 		6E64D06A2A149CE40076C61E /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 			children = (
 				6E64D0D22A29FE720076C61E /* Main */,
 				6E66C4CA2A03955B007C4482 /* CarParkInfoViewController.swift */,
+				6E569EA62A7A50C800E3E557 /* CarParkInfoViewModel.swift */,
 				6E64D0AC2A1E48600076C61E /* FavoriteParkViewController.swift */,
 				6E64D0DA2A2F50490076C61E /* FirstViewController.swift */,
 				6EA7BE5329BB5AA00046BDCC /* SearchResultViewController.swift */,
@@ -385,6 +388,7 @@
 				6EA7BE4029BB24A30046BDCC /* AppDelegate.swift in Sources */,
 				6E64D0752A1763960076C61E /* ViewController+CameraDelegate.swift in Sources */,
 				6E64D0BF2A2495C20076C61E /* NetworkResult.swift in Sources */,
+				6E569EA72A7A50C800E3E557 /* CarParkInfoViewModel.swift in Sources */,
 				6E64D0CB2A28AB2E0076C61E /* LoginViewController.swift in Sources */,
 				6EA7BE5429BB5AA00046BDCC /* SearchResultViewController.swift in Sources */,
 				6E64D0B72A20AE440076C61E /* ParkReview.swift in Sources */,

--- a/CarPark/ViewControllers/CarParkInfoViewModel.swift
+++ b/CarPark/ViewControllers/CarParkInfoViewModel.swift
@@ -1,0 +1,87 @@
+import UIKit
+import Combine
+
+protocol DrivingDelegate: AnyObject {
+    func getDriving(goalLng: String, goalLat: String, goalLocation: String, marker: ParkMarker)
+}
+
+final class CarParkInfoViewModel: NSObject, ObservableObject {
+    @Published private(set) var reviews: [ParkReview]?
+    
+    let tempData: [ParkReview] = [ParkReview(user_Name: "gkgk", review: "review~", date: "2023-08-04", park_Name: "zz"),ParkReview(user_Name: "gkgk", review: "review~123", date: "2023-08-04", park_Name: "zz"),ParkReview(user_Name: "gkgk", review: "review~456", date: "2023-08-04", park_Name: "zz"),]
+    
+    let marker: ParkMarker
+    
+    weak var delegate: DrivingDelegate?
+    
+    init(marker: ParkMarker) {
+        self.marker = marker
+        super.init()
+        viewDidLoad()
+        
+        // MARK: 데이터 바인딩 Test
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            self.reviews = self.tempData
+        }
+    }
+    
+    private func viewDidLoad() {
+        fetchReview()
+    }
+    
+    func checkFavorite() -> Bool {
+        UserDefault.shared.checkFavorite(with: self.marker.data)
+    }
+    
+    func tappedFavoriteAction() {
+        UserDefault.shared.setFavoriteParks(item: self.marker.data)
+    }
+    
+    func getDriving() {
+        delegate?.getDriving(goalLng: marker.data.xCdnt, goalLat: marker.data.yCdnt, goalLocation: marker.data.pkNam, marker: marker)
+    }
+    
+    func postReview(with review: String) {
+        let parameter: [String: Any] = [
+            "user_Name" : UserDefault.shared.getNickname(),
+            "review" : review,
+            "park_Name" : self.marker.data.pkNam
+        ]
+
+        NetworkManager.shared.push(with: APIConstants.saveReviewURL, parameter: parameter) { result in
+            guard result == .success else {
+                print("review error")
+                return
+            }
+            self.fetchReview()
+        }
+    }
+    
+    // MARK: 서버에서 리뷰를 가져오는 함수
+    private func fetchReview() {
+        let urlParkName = marker.data.pkNam.components(separatedBy: " ").joined()
+        let encodeURL = (APIConstants.fetchReviewURL + urlParkName).encodeUrl()!
+
+        NetworkManager.shared.fetch(with: encodeURL, type: ParkReviewStatus.self) { reviewData in
+            self.reviews = reviewData.reviews
+        }
+    }
+}
+
+// MARK: 테이블 뷰 관련
+extension CarParkInfoViewModel: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        reviews?.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ParkReviewCell.identifier, for: indexPath) as? ParkReviewCell else { return UITableViewCell() }
+        guard let reviews else { return UITableViewCell() }
+        let review = reviews[indexPath.row]
+        cell.configure(with: review)
+
+        return cell
+    }
+}
+
+extension CarParkInfoViewModel: UITableViewDelegate { }

--- a/CarPark/Views/ParkMarker.swift
+++ b/CarPark/Views/ParkMarker.swift
@@ -42,13 +42,13 @@ final class ParkMarker: NMFMarker {
             if self.drivingMarker { return false }
             
             let sheetVC: CarParkInfoViewController = UIStoryboard(name: "CarParkInfoView", bundle: nil).instantiateViewController(identifier: "CarParkInfoView") { coder in
-                let vc = CarParkInfoViewController(marker: self, coder: coder)
+                let vc = CarParkInfoViewController(viewModel: CarParkInfoViewModel(marker: self), coder: coder)
                 return vc
             }
             if let presentationSheetVC = sheetVC.presentationController as? UISheetPresentationController {
                 presentationSheetVC.detents = [.medium(), .large()]
                 presentationSheetVC.prefersGrabberVisible = true
-                sheetVC.delegate = vc
+                sheetVC.viewModel.delegate = vc
                 self.vc?.present(sheetVC, animated: true)
             }
             

--- a/CarPark/Views/ParkTitleCell.swift
+++ b/CarPark/Views/ParkTitleCell.swift
@@ -53,14 +53,14 @@ final class ParkTitleCell: UITableViewCell {
                 guard let marker = ParkDB.shared.allMarkers.filter({ $0.data.pkNam == item.pkNam }).first else { return }
                 
                 let sheetVC: CarParkInfoViewController = UIStoryboard(name: "CarParkInfoView", bundle: nil).instantiateViewController(identifier: "CarParkInfoView") { coder in
-                    let vc = CarParkInfoViewController(marker: marker, coder: coder)
+                    let vc = CarParkInfoViewController(viewModel: CarParkInfoViewModel(marker: marker), coder: coder)
                     return vc
                 }
                 
                 if let presentationSheetVC = sheetVC.presentationController as? UISheetPresentationController {
                     presentationSheetVC.detents = [.medium(), .large()]
                     presentationSheetVC.prefersGrabberVisible = true
-                    sheetVC.delegate = vc
+                    sheetVC.viewModel.delegate = vc
                     vc.NM.mapView.becomeFirstResponder()
                     vc.present(sheetVC, animated: true)
                 }


### PR DESCRIPTION
> MVC로 구성된 프로젝트를 MVVM으로 리팩토링 헤보려고 함

CarParkInfoViewController에서 UI와 밀접하게 관련된 부분 말고는 뷰 모델로 로직들을 옮겼는데 이게 맞는지는 잘 모르게씀,,

### 수정사항

- UITableView의 데이터소스, 딜리게이트를 뷰 모델로 옮겼다 (VC를 가볍게 하기 위함)
- 뷰 컨트롤러에서 들고 있는 데이터를 뷰모델로 옮겨서 뷰 모델 변수만 가지고 있도록 함
- 리뷰 작성, fetch 관련 로직도 뷰 모델을 거쳐서 하게끔 수정함
- 텍스트필드, 키보드 관련 로직들은 VC에서 하는게 낫다고 생각하여 놔뒀다
- Combine을 매우 매우 간단하게 사용하여 데이터 바인딩을 하였다
    - RxSwift라면 좀 더 UI 부분도 연결하여 뷰 모델로 더 로직들을 몰아 넣을 수 있을거같기도함 

---

### 고민사항

아무래도 MVVM을 사용하는 부분이 처음이라 어느정도까지 분리를 해야하는건지 이 기준이 아직 애매하게 느껴짐. 테이블 뷰의 딜리게이트를 뷰 모델에 적용한 부분도 VC를 가볍게 하기 위함이라 딱히 큰 이유는 없슴,, 셀을 생성하는 부분은 VC가 들고 있는게 맞는거 같기도하고.. 뷰 모델에서 해도 상관은 없어보이기도하고.. 어렵네야 ~