### PR TITLE
[Refactor] Publisher extension 추가, JoinVC, JoinVM 리팩토링

### DIFF
--- a/CarPark.xcodeproj/project.pbxproj
+++ b/CarPark.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		6EB3B89F2A02380B0084F927 /* Park.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3B89E2A02380B0084F927 /* Park.swift */; };
 		6EDE887A2A7E5ECF00E18808 /* JoinViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE88792A7E5ECF00E18808 /* JoinViewModel.swift */; };
 		6EDE887F2A7E5F9200E18808 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE887E2A7E5F9200E18808 /* BaseViewController.swift */; };
+		6EDE88852A80DB9600E18808 /* Publisher+UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE88842A80DB9600E18808 /* Publisher+UIComponents.swift */; };
+		6EDE88872A80E01600E18808 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE88862A80E01600E18808 /* ViewModelType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -103,6 +105,8 @@
 		6EB3B89E2A02380B0084F927 /* Park.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Park.swift; sourceTree = "<group>"; };
 		6EDE88792A7E5ECF00E18808 /* JoinViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinViewModel.swift; sourceTree = "<group>"; };
 		6EDE887E2A7E5F9200E18808 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		6EDE88842A80DB9600E18808 /* Publisher+UIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+UIComponents.swift"; sourceTree = "<group>"; };
+		6EDE88862A80E01600E18808 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		BF2F755975BD6FF83E1AA140 /* Pods-CarPark.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CarPark.debug.xcconfig"; path = "Target Support Files/Pods-CarPark/Pods-CarPark.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -143,6 +147,7 @@
 				6E64D0BA2A233A0F0076C61E /* Date+.swift */,
 				6E64D0D82A2CB0D60076C61E /* String+.swift */,
 				6E64D0CE2A29EC780076C61E /* UIViewController+.swift */,
+				6EDE88842A80DB9600E18808 /* Publisher+UIComponents.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -265,6 +270,7 @@
 			isa = PBXGroup;
 			children = (
 				6EDE887E2A7E5F9200E18808 /* BaseViewController.swift */,
+				6EDE88862A80E01600E18808 /* ViewModelType.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -403,7 +409,9 @@
 				6E66C4CB2A03955B007C4482 /* CarParkInfoViewController.swift in Sources */,
 				6EB3B89A2A00FB370084F927 /* PartnerPark.swift in Sources */,
 				6E64D0A92A1DC1D40076C61E /* CustomInfoWindowDataSource.swift in Sources */,
+				6EDE88852A80DB9600E18808 /* Publisher+UIComponents.swift in Sources */,
 				6E64D06D2A1658490076C61E /* UserDefault.swift in Sources */,
+				6EDE88872A80E01600E18808 /* ViewModelType.swift in Sources */,
 				6E64D0712A1739100076C61E /* ParkDB.swift in Sources */,
 				6EA7BE5629BB5AC90046BDCC /* ParkTitleCell.swift in Sources */,
 				6EB3B89F2A02380B0084F927 /* Park.swift in Sources */,

--- a/CarPark/Base/ViewModelType.swift
+++ b/CarPark/Base/ViewModelType.swift
@@ -1,0 +1,9 @@
+import Combine
+import Foundation
+
+protocol ViewModelType {
+    associatedtype Input
+    associatedtype Output
+    
+    func transform(input: Input) -> Output
+}

--- a/CarPark/Extensions/Publisher+UIComponents.swift
+++ b/CarPark/Extensions/Publisher+UIComponents.swift
@@ -1,0 +1,67 @@
+import UIKit
+import Combine
+
+extension UIControl {
+    func controlPublisher(for event: UIControl.Event) -> UIControl.EventPublisher {
+        return UIControl.EventPublisher(control: self, event: event)
+    }
+    
+    // Publisher
+    struct EventPublisher: Publisher {
+        typealias Output = UIControl
+        typealias Failure = Never
+        
+        let control: UIControl
+        let event: UIControl.Event
+        
+        func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, UIControl == S.Input {
+            let subscription = EventSubscription(control: control, subscrier: subscriber, event: event)
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    // Subscription
+    fileprivate class EventSubscription<EventSubscriber: Subscriber>: Subscription where EventSubscriber.Input == UIControl, EventSubscriber.Failure == Never {
+        
+        let control: UIControl
+        let event: UIControl.Event
+        var subscriber: EventSubscriber?
+        
+        init(control: UIControl, subscrier: EventSubscriber, event: UIControl.Event) {
+            self.control = control
+            self.subscriber = subscrier
+            self.event = event
+            
+            control.addTarget(self, action: #selector(eventDidOccur), for: event)
+        }
+        
+        func request(_ demand: Subscribers.Demand) {}
+        
+        func cancel() {
+            subscriber = nil
+            control.removeTarget(self, action: #selector(eventDidOccur), for: event)
+        }
+        
+        @objc func eventDidOccur() {
+            _ = subscriber?.receive(control)
+        }
+    }
+    
+}
+
+extension UITextField {
+    var textPublisher: AnyPublisher<String, Never> {
+        controlPublisher(for: .editingChanged)
+            .map { $0 as! UITextField }
+            .map { $0.text! }
+            .eraseToAnyPublisher()
+    }
+}
+
+extension UIButton {
+    var tapPublisher: AnyPublisher<Void, Never> {
+        controlPublisher(for: .touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+}

--- a/CarPark/ViwModels/JoinViewModel.swift
+++ b/CarPark/ViwModels/JoinViewModel.swift
@@ -1,34 +1,49 @@
 import Foundation
 import Combine
 
-final class JoinViewModel {
-    
-    typealias VerifyTuple = (id: Bool, nickName: Bool, email: Bool, password: Bool)
-    
-    @Published var verifys: VerifyTuple = (false, false, false, false)
-    
-    func checkid(_ bool: Bool) {
-        verifys.id = bool
+final class JoinViewModel: ViewModelType {
+    struct Input {
+        let id: AnyPublisher<String, Never>
+        let nickName: AnyPublisher<String, Never>
+        let email: AnyPublisher<String, Never>
+        let password: AnyPublisher<String, Never>
+        let password2: AnyPublisher<String, Never>
     }
     
-    func checkNickname(_ bool: Bool) {
-        verifys.nickName = bool
+    struct Output {
+        let emailIsValid: AnyPublisher<Bool, Never>
+        let passwrodIsValid: AnyPublisher<Bool, Never>
+        let buttonIsValid: AnyPublisher<Bool, Never>
     }
     
-    func checkPassword(_ bool: Bool) -> Bool {
-        verifys.password = bool
+    func transform(input: Input) -> Output {
+        let emailStatePublisher = input.email
+            .map { self.checkEmail($0) }
+            .eraseToAnyPublisher()
         
-        return bool
-    }
-    
-    func checkEmail(_ bool: Bool) -> Bool {
-        verifys.email = bool
+        let passwordStatePublisher = input.password.combineLatest(input.password2)
+            .map { self.checkPassword($0, $1) }
+            .eraseToAnyPublisher()
         
-        return bool
+        let textCount = input.id.combineLatest(input.nickName, input.email)
+        let passwordCheck = input.password.combineLatest(input.password2)
+        
+        let buttonStatePublisher = textCount.combineLatest(passwordCheck)
+            .map { idNicknameEmail, password in
+                idNicknameEmail.0.count > 0 && idNicknameEmail.1.count > 0 && self.checkEmail(idNicknameEmail.2) && self.checkPassword(password.0, password.1)
+            }
+            .eraseToAnyPublisher()
+    
+        return Output(emailIsValid: emailStatePublisher, passwrodIsValid: passwordStatePublisher, buttonIsValid: buttonStatePublisher)
     }
     
-    func checkJoinBtn(with verifys: VerifyTuple) -> Bool {
-        verifys.id && verifys.email && verifys.password && verifys.nickName
+    func checkEmail(_ str: String) -> Bool {
+        let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        return str.count > 0 && NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: str)
+    }
+    
+    func checkPassword(_ str1: String, _ str2: String) -> Bool {
+        str1.count > 0 && str1 == str2
     }
     
     func joinAction(id: String?, pw: String?, email: String?, nickname: String?) {


### PR DESCRIPTION
> 이전까지는 혼자 생각으로 ViewModel을 만들었는데 다른 사람들의 코드를 참고해보니 Combine을 활용해서
> 좀 더 가독성이 좋으면서 UI 요소들도 연결하여 이벤트를 받는 방식을 주로 사용하는듯 하여 리팩토링을 했다

### 수정사항

- 뷰 모델 프로토콜을 추가함
    - ViewModel에 채택하여 Input, Output, transform 을 구현하여 사용한다
    - Input 부분의 데이터는 ViewController에서 bind하고 Input으로 받은 데이터를 바탕으로 ViewModel의 transform 메소드 내부에서 비즈니스 로직을 수행하여 Output으로 반환한다.
    - 반환한 Output의 결과 값들로 ViewController에서 UI 관련 로직을 수행함.
    - 흐름은 이렇게 되는듯함. 아마도
- UIControl을 구독할 수 있게 하는 코드를 추가하여 Button, TextField등을 구독할 수 있게함. Rx에서 버튼 탭하면 받는 이벤트 등을 Combine에서도 사용하기 위함
- 기존에 사용했던 @Published 튜플을 삭제하고, Publisher로 대체하였다
    - 아무래도 회원가입 하는 부분이라 유효성 검사를 위해서는 변수가 많을 수 밖에 없지 싶다.. 
    - combineLatest를 사용해서 이벤트를 묶어서 결과값을 방출함

### 고민사항/문제해결

- 회원가입 버튼을 누르고 일어나는 액션은 VC에서 버튼을 누르고 VM에서 메소드만 실행하면 되는 부분이라 Input에 추가하지 않았는데 일관성을 생각하면 넣어야 하나 싶은 고민이 있는데 정답은 잘 모르겠다 상황에 맞게 유연하게 택해야하나 싶기도하고,,,,,
-  Combine을 잘 몰라서 이벤트를 묶는 부분이 아직 미숙하다. 회원가입의 유효성 검사를 하기 위해 Input들을 다 묶어야 하는데 combineLatest는 최대 3개인가 4개까지만 묶이는 문제가 있었다
    - 그래서 Id, Nickname, Email 을 묶고, password끼리 묶어서 해당 Publisher들을 묶는 방법으로 해결을 함
    - Combine 오퍼레이터? 를 더 공부해야겠슴 