### PR TITLE
[Refactor] JoinButton 액션 수정

### DIFF
--- a/CarPark/Extensions/Publisher+UIComponents.swift
+++ b/CarPark/Extensions/Publisher+UIComponents.swift
@@ -56,6 +56,12 @@ extension UITextField {
             .map { $0.text! }
             .eraseToAnyPublisher()
     }
+    
+    var returnPublisher: AnyPublisher<Void, Never> {
+        controlPublisher(for: .editingDidEndOnExit)
+            .map { _ in }
+            .eraseToAnyPublisher()
+      }
 }
 
 extension UIButton {

--- a/CarPark/Managers/NetworkManager.swift
+++ b/CarPark/Managers/NetworkManager.swift
@@ -47,6 +47,7 @@ final class NetworkManager {
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
             guard let _ = response as? HTTPURLResponse else {
                 print("\(String(describing: response))")
+                completionHandler(.networkFail)
                 return
             }
             do {
@@ -60,6 +61,7 @@ final class NetworkManager {
             }
             catch {
                 print("data error")
+                completionHandler(.networkFail)
             }
         }
         task.resume()

--- a/CarPark/ViewControllers/JoinViewController.swift
+++ b/CarPark/ViewControllers/JoinViewController.swift
@@ -50,7 +50,6 @@ final class JoinViewController: BaseViewController {
         button.setTitleColor(.white, for: .selected)
         button.setTitleColor(.gray, for: .normal)
         button.tintColor = .black
-        button.addTarget(self, action: #selector(joinAction), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
@@ -100,6 +99,12 @@ final class JoinViewController: BaseViewController {
 
         let output = viewModel.transform(input: input)
         
+        joinButton.tapPublisher.sink { [weak self] state in
+            guard let self else { return }
+            if joinButton.isSelected { self.viewModel.joinAction(id: idTextField.text!, pw: passwordTextField2.text!, email: emailTextField.text!, nickname: nicknameTextField.text!) }
+        }
+        .store(in: &cancellable)
+        
         output
             .emailIsValid
             .sink { [weak self] state in
@@ -120,6 +125,17 @@ final class JoinViewController: BaseViewController {
                self?.joinButton.isSelected = state
            })
            .store(in: &cancellable)
+        
+        output
+            .networkState
+            .sink(receiveValue: { [weak self] state in
+                if state {
+                    DispatchQueue.main.async {
+                        self?.dismiss(animated: true)
+                    }
+                }
+            })
+            .store(in: &cancellable)
     }
     
     override func configureHierarchy() {
@@ -187,15 +203,6 @@ final class JoinViewController: BaseViewController {
            self.view.frame.origin.y = 0
        }
    }
-}
-
-extension JoinViewController {
-    @objc func joinAction() {
-        if joinButton.isSelected {
-            viewModel.joinAction(id: idTextField.text, pw: passwordTextField2.text, email: emailTextField.text, nickname: nicknameTextField.text)
-            self.dismiss(animated: true)
-        }
-    }
 }
 
 extension JoinViewController: UITextFieldDelegate {


### PR DESCRIPTION
### 수정사항

- 버튼의 addTarget을 tabPublisher 를 사용하여 JoinVC 내부에 bind로 옮김
    - bind 내부에서 이벤트를 감지하여 viewModel에 joinAction을 실행함
- 성공, 실패 여부를 ViewModel에 NetworkState를 만들어서 output으로 넘김
    - joinAction 내부의 push 메소드의 completionHandler내에서 self.networkState.send(false or true)로 상태를 변경하도록 만들었슴미다
- [weak self]를 추가하여 메모리 누수를 방지하였슴니다 

### 고민사항 / 문제해결

- 버튼의 액션을 input으로 넘겨서 viewModel에서 sink 하여 이벤트를 감지하는 방법을 추천받았는데, 뷰 모델에서 sink하여 이벤트를 감지해야해서 cancellable도 만들고 해야하는 부분이 조큼걸려서 지금처럼 vc의 bind 내부에서 이벤트 감지하고 뷰모델의 메소드를 호출하는식으로 구현을 했슴니다
    - 뷰 모델의 메소드를 호출하는게 조금 그런가 싶기도 한디 잘 모르겠네야,,, 요거도 괜찮아 보이기는 하는데 vc에서는 값의 변경 여부만 체크하는게 낫나 싶기도하거,,
- 회원가입의 성공 실패 여부를 뷰 모델에 CurrentValueSubject를 추가하여 구현을 했슴니다. 간단히 값을 변경하고 방출하는 친구라고 해서 괜찮아 보이긴 하는디,, 잘 사용한건지는 잘 모르게씀다
    - fetch, post 메소드를 AnyPublisher로 반환하게끔 만들거나 저 형태로 타입을 바꿔주는 부분도 공부를 해봐야할둣