### PR TITLE
[Refactor] get, post 메소드 리팩토링

### DIFF
--- a/CarPark.xcodeproj/project.pbxproj
+++ b/CarPark.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		6E64D0B92A20AF0D0076C61E /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0B82A20AF0D0076C61E /* NetworkManager.swift */; };
 		6E64D0BB2A233A0F0076C61E /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0BA2A233A0F0076C61E /* Date+.swift */; };
 		6E64D0BD2A2494630076C61E /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0BC2A2494630076C61E /* Secret.swift */; };
-		6E64D0BF2A2495C20076C61E /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0BE2A2495C20076C61E /* NetworkResult.swift */; };
+		6E64D0BF2A2495C20076C61E /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0BE2A2495C20076C61E /* NetworkError.swift */; };
 		6E64D0C12A2495FC0076C61E /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0C02A2495FC0076C61E /* APIConstants.swift */; };
 		6E64D0C52A25EB370076C61E /* Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0C42A25EB370076C61E /* Root.swift */; };
 		6E64D0C72A260D750076C61E /* ViewController+DrivingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0C62A260D750076C61E /* ViewController+DrivingDelegate.swift */; };
@@ -40,6 +40,8 @@
 		6E64D0DB2A2F50490076C61E /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E64D0DA2A2F50490076C61E /* FirstViewController.swift */; };
 		6E66C4CB2A03955B007C4482 /* CarParkInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66C4CA2A03955B007C4482 /* CarParkInfoViewController.swift */; };
 		6E66C4CD2A03DE31007C4482 /* CarParkInfoView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6E66C4CC2A03DE31007C4482 /* CarParkInfoView.storyboard */; };
+		6E7567F72A94B1F500CD0E35 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */; };
+		6E7567FD2A95DDDE00CD0E35 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7567FC2A95DDDE00CD0E35 /* HTTPStatusCode.swift */; };
 		6EA7BE4029BB24A30046BDCC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7BE3F29BB24A30046BDCC /* AppDelegate.swift */; };
 		6EA7BE4229BB24A30046BDCC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7BE4129BB24A30046BDCC /* SceneDelegate.swift */; };
 		6EA7BE4429BB24A30046BDCC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7BE4329BB24A30046BDCC /* ViewController.swift */; };
@@ -79,7 +81,7 @@
 		6E64D0B82A20AF0D0076C61E /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		6E64D0BA2A233A0F0076C61E /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		6E64D0BC2A2494630076C61E /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
-		6E64D0BE2A2495C20076C61E /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		6E64D0BE2A2495C20076C61E /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		6E64D0C02A2495FC0076C61E /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		6E64D0C42A25EB370076C61E /* Root.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Root.swift; sourceTree = "<group>"; };
 		6E64D0C62A260D750076C61E /* ViewController+DrivingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+DrivingDelegate.swift"; sourceTree = "<group>"; };
@@ -91,6 +93,8 @@
 		6E64D0DA2A2F50490076C61E /* FirstViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstViewController.swift; sourceTree = "<group>"; };
 		6E66C4CA2A03955B007C4482 /* CarParkInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarParkInfoViewController.swift; sourceTree = "<group>"; };
 		6E66C4CC2A03DE31007C4482 /* CarParkInfoView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CarParkInfoView.storyboard; sourceTree = "<group>"; };
+		6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		6E7567FC2A95DDDE00CD0E35 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		6EA7BE3C29BB24A30046BDCC /* CarPark.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarPark.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EA7BE3F29BB24A30046BDCC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6EA7BE4129BB24A30046BDCC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -245,7 +249,8 @@
 		6EB3B89B2A0235590084F927 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				6E64D0BE2A2495C20076C61E /* NetworkResult.swift */,
+				6E64D0BE2A2495C20076C61E /* NetworkError.swift */,
+				6E7567FC2A95DDDE00CD0E35 /* HTTPStatusCode.swift */,
 				6E64D06E2A166DE30076C61E /* Constant.swift */,
 				6E64D0BC2A2494630076C61E /* Secret.swift */,
 				6EB3B8992A00FB370084F927 /* PartnerPark.swift */,
@@ -253,6 +258,7 @@
 				6E64D0B62A20AE440076C61E /* ParkReview.swift */,
 				6E64D0C02A2495FC0076C61E /* APIConstants.swift */,
 				6E64D0C42A25EB370076C61E /* Root.swift */,
+				6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -409,6 +415,7 @@
 				6E66C4CB2A03955B007C4482 /* CarParkInfoViewController.swift in Sources */,
 				6EB3B89A2A00FB370084F927 /* PartnerPark.swift in Sources */,
 				6E64D0A92A1DC1D40076C61E /* CustomInfoWindowDataSource.swift in Sources */,
+				6E7567F72A94B1F500CD0E35 /* HTTPMethod.swift in Sources */,
 				6EDE88852A80DB9600E18808 /* Publisher+UIComponents.swift in Sources */,
 				6E64D06D2A1658490076C61E /* UserDefault.swift in Sources */,
 				6EDE88872A80E01600E18808 /* ViewModelType.swift in Sources */,
@@ -418,9 +425,10 @@
 				6E64D0CD2A28BA9F0076C61E /* JoinViewController.swift in Sources */,
 				6EA7BE4029BB24A30046BDCC /* AppDelegate.swift in Sources */,
 				6E64D0752A1763960076C61E /* ViewController+CameraDelegate.swift in Sources */,
-				6E64D0BF2A2495C20076C61E /* NetworkResult.swift in Sources */,
+				6E64D0BF2A2495C20076C61E /* NetworkError.swift in Sources */,
 				6E569EA72A7A50C800E3E557 /* CarParkInfoViewModel.swift in Sources */,
 				6E64D0CB2A28AB2E0076C61E /* LoginViewController.swift in Sources */,
+				6E7567FD2A95DDDE00CD0E35 /* HTTPStatusCode.swift in Sources */,
 				6EA7BE5429BB5AA00046BDCC /* SearchResultViewController.swift in Sources */,
 				6E64D0B72A20AE440076C61E /* ParkReview.swift in Sources */,
 				6E1241B32A050C7D003247DD /* ParkMarker.swift in Sources */,

--- a/CarPark/AppDelegate.swift
+++ b/CarPark/AppDelegate.swift
@@ -21,15 +21,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func fetchPartnerParks() {
-        NetworkManager.shared.fetch(with: APIConstants.partnerParkURL, type: Array<PartnerPark>.self) { data in
-            data.forEach { park in
-                let item = park.toParkItem()
-                ParkDB.shared.partnerParks.append(item)
-                ParkDB.shared.partnerMarkers.append(ParkMarker(data: item))
-            }
-            
-            DispatchQueue.main.async {
-                ParkDB.shared.allMarkers += ParkDB.shared.partnerMarkers
+        NetworkManager.shared.request(with: APIConstants.partnerParkURL, method: .get, type: Array<PartnerPark>.self) { result in
+            switch result {
+            case .success(let data):
+                data.forEach { park in
+                    let item = park.toParkItem()
+                    ParkDB.shared.partnerParks.append(item)
+                    ParkDB.shared.partnerMarkers.append(ParkMarker(data: item))
+                }
+                
+                DispatchQueue.main.async {
+                    ParkDB.shared.allMarkers += ParkDB.shared.partnerMarkers
+                }
+            case .failure(let error):
+                print("\(error)")
             }
         }
     }
@@ -42,16 +47,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
         
-        NetworkManager.shared.fetch(with: APIConstants.pubilcParkURL, type: Park.self) { data in
-            let parkData = data.getPblcPrkngInfo.body.items.item
-            ParkDB.shared.createTable()
-
-            parkData.forEach { item in
-                ParkDB.shared.markers.append(ParkMarker(data: item))
-                ParkDB.shared.insertData(item: item)
-            }
-            DispatchQueue.main.async {
-                ParkDB.shared.allMarkers += ParkDB.shared.markers
+        NetworkManager.shared.request(with: APIConstants.pubilcParkURL, method: .get, type: Park.self) { result in
+            switch result {
+            case .success(let data):
+                let parkData = data.getPblcPrkngInfo.body.items.item
+                ParkDB.shared.createTable()
+    
+                parkData.forEach { item in
+                    ParkDB.shared.markers.append(ParkMarker(data: item))
+                    ParkDB.shared.insertData(item: item)
+                }
+                DispatchQueue.main.async {
+                    ParkDB.shared.allMarkers += ParkDB.shared.markers
+                }
+            case .failure(let error):
+                print("\(error)")
             }
         }
     }

--- a/CarPark/Managers/NetworkManager.swift
+++ b/CarPark/Managers/NetworkManager.swift
@@ -5,8 +5,34 @@ final class NetworkManager {
     
     private init() { }
     
+    func request<T: Codable>(
+        with url: String, method: HTTPMethod, type: T.Type = HTTPStatusCode.self, parameter: [String: Any]? = nil, completion: @escaping (Result<T, NetworkError>) -> Void) {
+            switch method {
+            case .get:
+                fetch(with: url, type: T.self) { result in
+                    switch result {
+                    case .success(let data):
+                        completion(.success(data))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            case .post:
+                push(with: url, parameter: parameter!) { result in
+                    switch result {
+                    case .success(let code):
+                        guard let code = code as? T else { return }
+                        completion(.success(code))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            default: break
+            }
+        }
+    
     /// 서버에서 데이터를 들고오는 함수, 데이터 타입을 파라미터에 넘겨야 합니다
-    func fetch<T>(session: URLSession = URLSession(configuration: .default), with url: String, type: T.Type, completionHandler: @escaping (T) -> Void) where T: Codable {
+    func fetch<T: Codable>(session: URLSession = URLSession(configuration: .default), with url: String, type: T.Type, completion: @escaping (Result<T, NetworkError>) -> Void) {
         let url = URL(string: url)!
         
         let task = session.dataTask(with: url) { data, response, error in
@@ -15,23 +41,23 @@ final class NetworkManager {
                 return
             }
             guard let data = data else { return }
-
+            
             do {
                 let decoder = JSONDecoder()
                 let data = try decoder.decode(T.self, from: data)
-                completionHandler(data)
+                completion(.success(data))
                 
             } catch let error as NSError{
                 print("error: \(error)")
             }
         }
-
+        
         task.resume()
     }
     
     /// 서버에 데이터를 보내는 함수,
     /// 완료 핸들러에 넘겨지는 NetworkResult로 성공여부를 판단해야합니다
-    func push(with url: String, parameter data: [String:Any], completionHandler: @escaping (NetworkResult) -> Void) {
+    func push(with url: String, parameter data: [String:Any], completion: @escaping (Result<HTTPStatusCode, NetworkError>) -> Void) {
         let url = URL(string: url)!
         
         var request = URLRequest(url: url)
@@ -47,23 +73,24 @@ final class NetworkManager {
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
             guard let _ = response as? HTTPURLResponse else {
                 print("\(String(describing: response))")
-                completionHandler(.networkFail)
+                completion(.failure(.networkFail))
                 return
             }
             do {
                 let data = try JSONSerialization.jsonObject(with: data!, options: []) as? NSDictionary
                 
                 guard let status = data?["code"] as? Int, status == 200 else {
-                    completionHandler(.networkFail)
+                    completion(.failure(.serverErr))
                     return
                 }
-                completionHandler(.success)
+                completion(.success(.ok))
             }
             catch {
                 print("data error")
-                completionHandler(.networkFail)
+                completion(.failure(.requestErr))
             }
         }
         task.resume()
     }
 }
+

--- a/CarPark/Model/HTTPMethod.swift
+++ b/CarPark/Model/HTTPMethod.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum HTTPMethod {
+    case get
+    case post
+    case put
+    case patch
+    case delete
+}

--- a/CarPark/Model/HTTPStatusCode.swift
+++ b/CarPark/Model/HTTPStatusCode.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum HTTPStatusCode: Int, Codable {
+    case ok = 200
+    case forbidden = 403
+    case notFound = 404
+}

--- a/CarPark/Model/NetworkError.swift
+++ b/CarPark/Model/NetworkError.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-enum NetworkResult {
-    case success
+enum NetworkError: Error {
     case requestErr
     case pathErr
     case serverErr

--- a/CarPark/ViewControllers/JoinViewController.swift
+++ b/CarPark/ViewControllers/JoinViewController.swift
@@ -121,20 +121,18 @@ final class JoinViewController: BaseViewController {
         
         output
            .buttonIsValid
-           .sink(receiveValue: { [weak self] state in
+           .sink { [weak self] state in
                self?.joinButton.isSelected = state
-           })
+           }
            .store(in: &cancellable)
         
         output
             .networkState
-            .sink(receiveValue: { [weak self] state in
-                if state {
-                    DispatchQueue.main.async {
-                        self?.dismiss(animated: true)
-                    }
-                }
-            })
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                state ? self?.dismiss(animated: true) : ()
+//                if state { self?.dismiss(animated: true) }
+            }
             .store(in: &cancellable)
     }
     

--- a/CarPark/ViewControllers/LoginViewController.swift
+++ b/CarPark/ViewControllers/LoginViewController.swift
@@ -70,12 +70,11 @@ final class LoginViewController: UIViewController {
                 "user_PW" : passwordTextField.text!
             ]
             
-            NetworkManager.shared.push(with: APIConstants.loginURL, parameter: parameter) { result in
+            NetworkManager.shared.request(with: APIConstants.loginURL, method: .post, parameter: parameter) { result in
                 // MARK: 로그인 성공
-                if result == .success {
-                    print("success")
+                switch result {
+                case .success(_):
                     DispatchQueue.main.async {
-                        print("success23")
                         UserDefault.shared.setLogin(id: self.idTextField.text ?? "", nickname: UserDefault.shared.getNickname())
                         self.navigationController?.popViewController(animated: true)
                         self.navigationController?.popViewController(animated: true)
@@ -83,9 +82,8 @@ final class LoginViewController: UIViewController {
                         self.navigationController?.pushViewController(ViewController(), animated: false)
                         
                     }
-                }
-                // MARK: 로그인 실패
-                else {
+                case .failure(let error):
+                    print(error)
                     DispatchQueue.global().async {
                         let alertVC = UIAlertController(title: nil, message: "아이디 또는 비밀번호를 확인 해주세요", preferredStyle: .alert)
                         let yesAction = UIAlertAction(title: "확인", style: .default, handler: nil)

--- a/CarPark/ViewControllers/Main/ViewController+CameraDelegate.swift
+++ b/CarPark/ViewControllers/Main/ViewController+CameraDelegate.swift
@@ -102,8 +102,13 @@ extension ViewController: NMFMapViewCameraDelegate {
     }
     
     func fetchPartnerParks(completionHandler: @escaping ([PartnerPark]) -> Void) {
-        NetworkManager.shared.fetch(with: APIConstants.partnerParkURL, type: Array<PartnerPark>.self) { data in
-            completionHandler(data)
+        NetworkManager.shared.request(with: APIConstants.partnerParkURL, method: .get, type: Array<PartnerPark>.self) { result in
+            switch result {
+            case .success(let data):
+                completionHandler(data)
+            case .failure(let error):
+                print("\(error)")
+            }
         }
     }
 }

--- a/CarPark/ViwModels/CarParkInfoViewModel.swift
+++ b/CarPark/ViwModels/CarParkInfoViewModel.swift
@@ -48,12 +48,13 @@ final class CarParkInfoViewModel: NSObject, ObservableObject {
             "park_Name" : self.marker.data.pkNam
         ]
 
-        NetworkManager.shared.push(with: APIConstants.saveReviewURL, parameter: parameter) { result in
-            guard result == .success else {
-                print("review error")
-                return
+        NetworkManager.shared.request(with: APIConstants.saveReviewURL, method: .post, parameter: parameter) { result in
+            switch result {
+            case .success(_):
+                self.fetchReview()
+            case .failure(let error):
+                print("\(error)")
             }
-            self.fetchReview()
         }
     }
     
@@ -61,9 +62,14 @@ final class CarParkInfoViewModel: NSObject, ObservableObject {
     private func fetchReview() {
         let urlParkName = marker.data.pkNam.components(separatedBy: " ").joined()
         let encodeURL = (APIConstants.fetchReviewURL + urlParkName).encodeUrl()!
-
-        NetworkManager.shared.fetch(with: encodeURL, type: ParkReviewStatus.self) { reviewData in
-            self.reviews = reviewData.reviews
+        
+        NetworkManager.shared.request(with: encodeURL, method: .get, type: ParkReviewStatus.self) { result in
+            switch result {
+            case .success(let data):
+                self.reviews = data.reviews
+            case .failure(let error):
+                print("\(error)")
+            }
         }
     }
 }

--- a/CarPark/ViwModels/JoinViewModel.swift
+++ b/CarPark/ViwModels/JoinViewModel.swift
@@ -17,6 +17,7 @@ final class JoinViewModel: ViewModelType {
         let networkState: CurrentValueSubject<Bool, Never>
     }
     
+    var cancellable: Set<AnyCancellable> = []
     var networkState = CurrentValueSubject<Bool, Never>(false)
     
     func transform(input: Input) -> Output {
@@ -65,15 +66,16 @@ final class JoinViewModel: ViewModelType {
             "user_Name" : nickname
         ]
         
-        NetworkManager.shared.push(with: APIConstants.joinURL, parameter: parameter) { result in
-            if result != .success {
+        NetworkManager.shared.request(with: APIConstants.joinURL, method: .post, parameter: parameter) { result in
+            switch result {
+            case .success(_):
+                self.networkState.send(true)
+            case .failure(_):
                 UserDefault.shared.setLogout()
                 self.networkState.send(false)
                 print("회원가입 오류")
                 return
             }
-            self.networkState.send(true)
         }
-        
     }
 }


### PR DESCRIPTION
### 수정사항

- 기존의 get, post 메소드를 작성해서 수행하던 부분을 request 메소드로 같이 받도록 바꿈
    - request 메소드 내부에서 switch문을 사용해서 인자의 method에 따라서 다른 동작을 수행하도록 함
    - Alamofire 내부가 살짝 이런식으로 수행하는듯해서 해보았는데 개인적으로는 따로 만드는것도 좋아보이긴함
    - 라이브러리 쓰는게 좀 더 깔끔한 코드였을거같긴함,,
- Result 타입으로 반환하여 성공 실패 여부에 따라 동작을 다 나눠주었음

### 고민사항 / 문제해결

- 하나의 함수에 인자를 무엇을 받냐에 따라 동작을 다르게 하다보니 조금 막히는 부분이 있었는데, post의 경우 딱히 타입을 명시하지 않아도 잘 동작 하였는데 get은 반드시 타입을 인자에 작성해서 반환할 때 해당 타입으로 반환을 받고 있었다
    - 이 부분에서 통일을 하려고 하다보니 type 인자에 POST라는 Codable한 구조체를 만들어서 기본값으로 두어서 먼저 해결을 했었다
    - POST 구조체는 내부가 다 비어있는 추상적인 친구라서 성공해도 값을 따로 반환하지는 않았다 그래서 이렇게 하기 보다는 HTTPStatusCode로 변경하는게 좋아보여서 변경함
    -  enum을 만들고 Codable을 채택해서 성공코드 200과 실패코드를 넣어서 만들었고 post의 경우 status를 반환하게 만들었다

이렇게 하는게 괜찮은지는 잘 감이 오지않지만,, 개발할 때 서버 상황에 맞게 성공하는지를 나타내는 JSON을 받는 경우에는 위처럼비슷하게 하거나 해당 JSON의 구조체를 만들어서 타입에 기본값으로 두고 반환하게 하는것도 좋아보인다