### PR TITLE
[Add, Refactor]: 유저 주차장 마커, 정보 뷰 컨트롤러를 구현하였습니다.

### DIFF
--- a/CarPark.xcodeproj/project.pbxproj
+++ b/CarPark.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		6E7567F72A94B1F500CD0E35 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */; };
 		6E7567FD2A95DDDE00CD0E35 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7567FC2A95DDDE00CD0E35 /* HTTPStatusCode.swift */; };
 		6E9420052AD6B79C00AF725A /* UsageRecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9420042AD6B79C00AF725A /* UsageRecordViewController.swift */; };
+		6E967F062B1B3F3B00420C54 /* ImagePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E967F052B1B3F3B00420C54 /* ImagePageViewController.swift */; };
+		6E967F082B1B445600420C54 /* ImageContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E967F072B1B445600420C54 /* ImageContentViewController.swift */; };
 		6E9DD99A2AFB3BE900042FF6 /* BottomSheetBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9DD9992AFB3BE900042FF6 /* BottomSheetBtn.swift */; };
 		6E9DD99C2AFB421700042FF6 /* NothingParkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9DD99B2AFB421700042FF6 /* NothingParkView.swift */; };
 		6E9DD99E2AFB479C00042FF6 /* FilterParkHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9DD99D2AFB479C00042FF6 /* FilterParkHeaderView.swift */; };
@@ -115,6 +117,8 @@
 		6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		6E7567FC2A95DDDE00CD0E35 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		6E9420042AD6B79C00AF725A /* UsageRecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageRecordViewController.swift; sourceTree = "<group>"; };
+		6E967F052B1B3F3B00420C54 /* ImagePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePageViewController.swift; sourceTree = "<group>"; };
+		6E967F072B1B445600420C54 /* ImageContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageContentViewController.swift; sourceTree = "<group>"; };
 		6E9DD9992AFB3BE900042FF6 /* BottomSheetBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetBtn.swift; sourceTree = "<group>"; };
 		6E9DD99B2AFB421700042FF6 /* NothingParkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NothingParkView.swift; sourceTree = "<group>"; };
 		6E9DD99D2AFB479C00042FF6 /* FilterParkHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterParkHeaderView.swift; sourceTree = "<group>"; };
@@ -198,6 +202,8 @@
 				6EEA120D2AD6BD1800C57E9A /* MyMenuViewController.swift */,
 				6E6636582B10ABF80024FBF2 /* SubmitParkVCs */,
 				6E66365B2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift */,
+				6E967F052B1B3F3B00420C54 /* ImagePageViewController.swift */,
+				6E967F072B1B445600420C54 /* ImageContentViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -456,6 +462,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E6636572B10AB880024FBF2 /* SubimtParkViewController3.swift in Sources */,
+				6E967F062B1B3F3B00420C54 /* ImagePageViewController.swift in Sources */,
 				6E6636512B1050980024FBF2 /* SubmitParkViewController.swift in Sources */,
 				6E64D0B92A20AF0D0076C61E /* NetworkManager.swift in Sources */,
 				6E64D0BD2A2494630076C61E /* Secret.swift in Sources */,
@@ -478,6 +485,7 @@
 				6E66365C2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift in Sources */,
 				6E64D0D92A2CB0D60076C61E /* String+.swift in Sources */,
 				6E64D0C72A260D750076C61E /* ViewController+DrivingDelegate.swift in Sources */,
+				6E967F082B1B445600420C54 /* ImageContentViewController.swift in Sources */,
 				6EA7BE4429BB24A30046BDCC /* ViewController.swift in Sources */,
 				6E66C4CB2A03955B007C4482 /* CarParkInfoViewController.swift in Sources */,
 				6EEA12142AD6DFA700C57E9A /* RecordCell.swift in Sources */,

--- a/CarPark.xcodeproj/project.pbxproj
+++ b/CarPark.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6E6636532B1093BE0024FBF2 /* SubmitParkViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6636522B1093BE0024FBF2 /* SubmitParkViewController2.swift */; };
 		6E6636552B109E190024FBF2 /* SubmitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6636542B109E190024FBF2 /* SubmitViewModel.swift */; };
 		6E6636572B10AB880024FBF2 /* SubimtParkViewController3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6636562B10AB880024FBF2 /* SubimtParkViewController3.swift */; };
+		6E66365C2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66365B2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift */; };
 		6E66C4CB2A03955B007C4482 /* CarParkInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66C4CA2A03955B007C4482 /* CarParkInfoViewController.swift */; };
 		6E66C4CD2A03DE31007C4482 /* CarParkInfoView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6E66C4CC2A03DE31007C4482 /* CarParkInfoView.storyboard */; };
 		6E7567F72A94B1F500CD0E35 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */; };
@@ -59,7 +60,7 @@
 		6EA7BE5429BB5AA00046BDCC /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7BE5329BB5AA00046BDCC /* SearchResultViewController.swift */; };
 		6EA7BE5629BB5AC90046BDCC /* ParkTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7BE5529BB5AC90046BDCC /* ParkTitleCell.swift */; };
 		6EB3B89A2A00FB370084F927 /* PartnerPark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3B8992A00FB370084F927 /* PartnerPark.swift */; };
-		6EB3B89F2A02380B0084F927 /* Park.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3B89E2A02380B0084F927 /* Park.swift */; };
+		6EB3B89F2A02380B0084F927 /* ParkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3B89E2A02380B0084F927 /* ParkModel.swift */; };
 		6EDE887A2A7E5ECF00E18808 /* JoinViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE88792A7E5ECF00E18808 /* JoinViewModel.swift */; };
 		6EDE887F2A7E5F9200E18808 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE887E2A7E5F9200E18808 /* BaseViewController.swift */; };
 		6EDE88852A80DB9600E18808 /* Publisher+UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE88842A80DB9600E18808 /* Publisher+UIComponents.swift */; };
@@ -108,6 +109,7 @@
 		6E6636522B1093BE0024FBF2 /* SubmitParkViewController2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitParkViewController2.swift; sourceTree = "<group>"; };
 		6E6636542B109E190024FBF2 /* SubmitViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitViewModel.swift; sourceTree = "<group>"; };
 		6E6636562B10AB880024FBF2 /* SubimtParkViewController3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubimtParkViewController3.swift; sourceTree = "<group>"; };
+		6E66365B2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCarParkInfoViewController.swift; sourceTree = "<group>"; };
 		6E66C4CA2A03955B007C4482 /* CarParkInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarParkInfoViewController.swift; sourceTree = "<group>"; };
 		6E66C4CC2A03DE31007C4482 /* CarParkInfoView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CarParkInfoView.storyboard; sourceTree = "<group>"; };
 		6E7567F62A94B1F500CD0E35 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -127,7 +129,7 @@
 		6EA7BE5329BB5AA00046BDCC /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		6EA7BE5529BB5AC90046BDCC /* ParkTitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkTitleCell.swift; sourceTree = "<group>"; };
 		6EB3B8992A00FB370084F927 /* PartnerPark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartnerPark.swift; sourceTree = "<group>"; };
-		6EB3B89E2A02380B0084F927 /* Park.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Park.swift; sourceTree = "<group>"; };
+		6EB3B89E2A02380B0084F927 /* ParkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkModel.swift; sourceTree = "<group>"; };
 		6EDE88792A7E5ECF00E18808 /* JoinViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinViewModel.swift; sourceTree = "<group>"; };
 		6EDE887E2A7E5F9200E18808 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		6EDE88842A80DB9600E18808 /* Publisher+UIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+UIComponents.swift"; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 				6E9420042AD6B79C00AF725A /* UsageRecordViewController.swift */,
 				6EEA120D2AD6BD1800C57E9A /* MyMenuViewController.swift */,
 				6E6636582B10ABF80024FBF2 /* SubmitParkVCs */,
+				6E66365B2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -295,7 +298,7 @@
 				6E64D06E2A166DE30076C61E /* Constant.swift */,
 				6E64D0BC2A2494630076C61E /* Secret.swift */,
 				6EB3B8992A00FB370084F927 /* PartnerPark.swift */,
-				6EB3B89E2A02380B0084F927 /* Park.swift */,
+				6EB3B89E2A02380B0084F927 /* ParkModel.swift */,
 				6E64D0B62A20AE440076C61E /* ParkReview.swift */,
 				6E64D0C02A2495FC0076C61E /* APIConstants.swift */,
 				6E64D0C42A25EB370076C61E /* Root.swift */,
@@ -472,6 +475,7 @@
 				6E64D0DB2A2F50490076C61E /* FirstViewController.swift in Sources */,
 				6E64D0BB2A233A0F0076C61E /* Date+.swift in Sources */,
 				6E64D0B52A20AD940076C61E /* ParkReviewCell.swift in Sources */,
+				6E66365C2B19C7C00024FBF2 /* UserCarParkInfoViewController.swift in Sources */,
 				6E64D0D92A2CB0D60076C61E /* String+.swift in Sources */,
 				6E64D0C72A260D750076C61E /* ViewController+DrivingDelegate.swift in Sources */,
 				6EA7BE4429BB24A30046BDCC /* ViewController.swift in Sources */,
@@ -487,7 +491,7 @@
 				6EA7BE5629BB5AC90046BDCC /* ParkTitleCell.swift in Sources */,
 				6EEA12102AD6D5A700C57E9A /* DividerView.swift in Sources */,
 				6E9420052AD6B79C00AF725A /* UsageRecordViewController.swift in Sources */,
-				6EB3B89F2A02380B0084F927 /* Park.swift in Sources */,
+				6EB3B89F2A02380B0084F927 /* ParkModel.swift in Sources */,
 				6E64D0CD2A28BA9F0076C61E /* JoinViewController.swift in Sources */,
 				6EA7BE4029BB24A30046BDCC /* AppDelegate.swift in Sources */,
 				6E64D0752A1763960076C61E /* ViewController+CameraDelegate.swift in Sources */,

--- a/CarPark/AppDelegate.swift
+++ b/CarPark/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 data.forEach { park in
                     let item = park.toParkItem()
                     ParkDB.shared.partnerParks.append(item)
-                    ParkDB.shared.partnerMarkers.append(ParkMarker(data: item))
+                    ParkDB.shared.partnerMarkers.append(ParkMarker(park: item))
                 }
                 
                 DispatchQueue.main.async {
@@ -42,19 +42,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func fetchParks() {
         if ParkDB.shared.data.count > 0 {
             ParkDB.shared.data.forEach { item in
-                ParkDB.shared.markers.append(ParkMarker(data: item))
+                ParkDB.shared.markers.append(ParkMarker(park: item))
             }
             return
         }
         
-        NetworkManager.shared.request(with: APIConstants.pubilcParkURL, method: .get, type: Park.self) { result in
+        NetworkManager.shared.request(with: APIConstants.pubilcParkURL, method: .get, type: ParkModel.self) { result in
             switch result {
             case .success(let data):
-                let parkData = data.getPblcPrkngInfo.body.items.item
+                let parkData = data.getPblcPrkngInfo.body.items.parks
                 ParkDB.shared.createTable()
     
                 parkData.forEach { item in
-                    ParkDB.shared.markers.append(ParkMarker(data: item))
+                    ParkDB.shared.markers.append(ParkMarker(park: item))
                     ParkDB.shared.insertData(item: item)
                 }
                 DispatchQueue.main.async {

--- a/CarPark/Extensions/Date+.swift
+++ b/CarPark/Extensions/Date+.swift
@@ -13,6 +13,7 @@ extension Date {
         case yearAndMonth = "YYYY년 M월"
         case yearAndMonthandDate2 = "YYYY.MM.dd."
         case yearAndMonthandDate3 = "YYYYMMdd"
+        case monthAndDayAndHourAndMinute = "MM월 dd일 HH:mm"
     }
     
     // MARK: Methods

--- a/CarPark/Managers/ParkDB.swift
+++ b/CarPark/Managers/ParkDB.swift
@@ -4,18 +4,18 @@ import CoreLocation
 
 final class ParkDB {
     static let shared = ParkDB()
-    private var _data: [Item]?
+    private var _data: [Park]?
     
     var markers: [ParkMarker] = []
     
-    var partnerParks: [Item] = []
+    var partnerParks: [Park] = []
     var partnerMarkers: [ParkMarker] = []
     
     var allMarkers: [ParkMarker] = []
     
     @Published private(set) var isShowParks: [ParkMarker] = []
     
-    var data: [Item] {
+    var data: [Park] {
         get {
             guard let data = self._data, !data.isEmpty else {
                 self._data = readData()
@@ -87,7 +87,7 @@ final class ParkDB {
         sqlite3_finalize(statement)
     }
     
-    func insertData(item: Item) {
+    func insertData(item: Park) {
         
         let insertQuery = "insert into ParkTable (id, guNm, pkNam, mgntNum, doroAddr, jibunAddr, tponNum, pkFm, pkCnt, svcSrtTe, svcEndTe, satSrtTe, satEndTe, hldSrtTe, hldEndTe, ldRtg, tenMin, ftDay, ftMon, xCdnt, yCdnt, fnlDt, pkGubun, bujeGubun, oprDay, feeInfo, pkBascTime, pkAddTime, feeAdd, ftDayApplytime, payMtd, spclNote, currava, oprtFm) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
         var statement: OpaquePointer? = nil
@@ -136,11 +136,11 @@ final class ParkDB {
         }
     }
     
-    func readData() -> [Item] {
+    func readData() -> [Park] {
         let query: String = "select * from ParkTable;"
         var statement: OpaquePointer? = nil
 
-        var result: [Item] = []
+        var result: [Park] = []
 
         if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
             let errorMessage = String(cString: sqlite3_errmsg(db)!)
@@ -184,7 +184,7 @@ final class ParkDB {
             let currava = String(cString: sqlite3_column_text(statement, 32))
             let oprtFm = String(cString: sqlite3_column_text(statement, 33))
             
-            result.append(Item(guNm: String(gnNm), pkNam: String(pkNam), mgntNum: String(mgntNum), doroAddr: doroAddr, jibunAddr: jibunAddr, tponNum: tponNum, pkFm: pkFm, pkCnt: pkCnt, svcSrtTe: svcSrtTe, svcEndTe: svcEndTe, satSrtTe: satSrtTe, satEndTe: satEndTe, hldSrtTe: hldSrtTe, hldEndTe: hldEndTe, ldRtg: ldRtg, tenMin: tenMin, ftDay: ftDay, ftMon: ftMon, xCdnt: xCdnt, yCdnt: yCdnt, fnlDt: fnlDt, pkGubun: pkGubun, bujeGubun: bujeGubun, oprDay: oprDay, feeInfo: feeInfo, pkBascTime: pkBascTime, pkAddTime: pkAddTime, feeAdd: feeAdd, ftDayApplytime: ftDayApplytime, payMtd: payMtd, spclNote: spclNote, currava: currava, oprtFm: oprtFm))
+            result.append(Park(guNm: String(gnNm), pkNam: String(pkNam), mgntNum: String(mgntNum), doroAddr: doroAddr, jibunAddr: jibunAddr, tponNum: tponNum, pkFm: pkFm, pkCnt: pkCnt, svcSrtTe: svcSrtTe, svcEndTe: svcEndTe, satSrtTe: satSrtTe, satEndTe: satEndTe, hldSrtTe: hldSrtTe, hldEndTe: hldEndTe, ldRtg: ldRtg, tenMin: tenMin, ftDay: ftDay, ftMon: ftMon, xCdnt: xCdnt, yCdnt: yCdnt, fnlDt: fnlDt, pkGubun: pkGubun, bujeGubun: bujeGubun, oprDay: oprDay, feeInfo: feeInfo, pkBascTime: pkBascTime, pkAddTime: pkAddTime, feeAdd: feeAdd, ftDayApplytime: ftDayApplytime, payMtd: payMtd, spclNote: spclNote, currava: currava, oprtFm: oprtFm))
         }
         sqlite3_finalize(statement)
         return result
@@ -207,8 +207,8 @@ final class ParkDB {
        
    }
     
-    func setRecommendParks(lat: Double, lng: Double) -> [Item] {
-        var parks: [Item]
+    func setRecommendParks(lat: Double, lng: Double) -> [Park] {
+        var parks: [Park]
         let current = CLLocationCoordinate2D(latitude: lat, longitude: lng)
         
         parks = data.sorted(by: { first, second in
@@ -219,8 +219,8 @@ final class ParkDB {
     }
     
     /// 관리 기관(guNm)이 같은 주차장들의 랜덤 주차장과, 개수를 반환하는 함수
-    func clusterItems() -> [(Item, Int)] {
-        var clusterItems: [(Item, Int)] = []
+    func clusterItems() -> [(Park, Int)] {
+        var clusterItems: [(Park, Int)] = []
         var isCheckedGuNm: Set<String> = []
         
         for item in data.reversed() {
@@ -241,9 +241,11 @@ final class ParkDB {
     }
     
     func setMarker(vc: ViewController) {
-        allMarkers = markers + partnerMarkers
-        allMarkers.forEach { item in
-            item.setTouchEvent(vc: vc)
+        self.allMarkers = self.markers + self.partnerMarkers
+        self.allMarkers.forEach { item in
+            item.vc = vc
+            item.mapView = vc.NM.mapView
+            item.setTouchEvent(vc: vc, data: item.park)
         }
     }
     

--- a/CarPark/Managers/UserDefault.swift
+++ b/CarPark/Managers/UserDefault.swift
@@ -5,9 +5,9 @@ final class UserDefault {
     private init() {}
     
     struct Parks: Codable {
-        var data: [Item]?
+        var data: [Park]?
         
-        init(data: [Item]? = nil) {
+        init(data: [Park]? = nil) {
             self.data = data
         }
     }
@@ -30,7 +30,7 @@ final class UserDefault {
         return nil
     }
     
-    func setRecentParks(item: Item) {
+    func setRecentParks(item: Park) {
         if let recentParks, var recentData = recentParks.data {
             if recentData.contains(item) { return }
             recentData.insert(item, at: 0)
@@ -53,7 +53,7 @@ final class UserDefault {
         UserDefaults.standard.removeObject(forKey: "RecentParks")
     }
     
-    func setFavoriteParks(item: Item) {
+    func setFavoriteParks(item: Park) {
         if let favoriteParks, var favoriteData = favoriteParks.data {
             if favoriteData.contains(item) {
                 favoriteData.remove(at: favoriteData.firstIndex(of: item)!)
@@ -71,7 +71,7 @@ final class UserDefault {
         
     }
     
-    func checkFavorite(with item: Item) -> Bool {
+    func checkFavorite(with item: Park) -> Bool {
         guard let favoriteParks, let favoriteData = favoriteParks.data else { return false }
         return favoriteData.contains(item)
     }

--- a/CarPark/Model/ParkModel.swift
+++ b/CarPark/Model/ParkModel.swift
@@ -1,8 +1,7 @@
-//   let parkAPI = try? JSONDecoder().decode(ParkAPI.self, from: jsonData)
 import Foundation
 
 // MARK: - ParkAPI
-struct Park: Codable {
+struct ParkModel: Codable {
     let getPblcPrkngInfo: GetPblcPrkngInfo
 }
 
@@ -14,17 +13,17 @@ struct GetPblcPrkngInfo: Codable {
 
 // MARK: - Body
 struct Body: Codable {
-    let items: Items
+    let items: Parks
     let numOfRows, pageNo, totalCount: Int
 }
 
 // MARK: - Items
-struct Items: Codable {
-    let item: [Item]
+struct Parks: Codable {
+    let parks: [Park]
 }
 
 // MARK: - Item
-struct Item: Codable, Equatable {
+struct Park: Codable, Equatable {
     var id: Int?
     var emptySpace: String?
     var handicapSpace: String?
@@ -47,6 +46,24 @@ struct Item: Codable, Equatable {
     static func ==(lhs: Self, rhs: Self) -> Bool {
         guard lhs.xCdnt == rhs.xCdnt && lhs.yCdnt == rhs.yCdnt else { return false }
         return true
+    }
+    
+    static func empty() -> Self {
+        Park(guNm: "", pkNam: "", mgntNum: "", doroAddr: "", jibunAddr: "", tponNum: "", pkFm: "", pkCnt: "", svcSrtTe: "", svcEndTe: "", satSrtTe: "", satEndTe: "", hldSrtTe: "", hldEndTe: "", ldRtg: "", tenMin: "", ftDay: "", ftMon: "", xCdnt: "", yCdnt: "", fnlDt: "", pkGubun: "", bujeGubun: "", oprDay: "", feeInfo: "", pkBascTime: "", pkAddTime: "", feeAdd: "", ftDayApplytime: "", payMtd: "", spclNote: "", currava: "", oprtFm: "")
+    }
+}
+
+// MARK: - 유저가 등록한 주차장 데이터 모델
+struct UserPark: Codable, Equatable {
+    let userNickname: String
+    let description: String
+    let lat: Double
+    let lng: Double
+    let startTime: String
+    let endTime: String
+    
+    static func empty() -> Self {
+        UserPark(userNickname: "", description: "", lat: 0.0, lng: 0.0, startTime: "", endTime: "")
     }
 }
 

--- a/CarPark/Model/PartnerPark.swift
+++ b/CarPark/Model/PartnerPark.swift
@@ -28,8 +28,8 @@ struct PartnerPark: Codable, Equatable {
         case parkPhone = "park_phone"
     }
     
-    func toParkItem() -> Item {
-        return Item(id: nil, emptySpace: String(parkEmpty), handicapSpace: String(handicapSpace), guNm: "", pkNam: parkName, mgntNum: "", doroAddr: parkAddress, jibunAddr: "", tponNum: parkPhone, pkFm: "", pkCnt: String(parkSpace), svcSrtTe: parkOperatingTime, svcEndTe: "", satSrtTe: "", satEndTe: "", hldSrtTe: "", hldEndTe: "", ldRtg: "", tenMin: parkBaseRate, ftDay: parkPerDayRate ?? "", ftMon: parkMonthlyRate ?? "", xCdnt: String(parkX), yCdnt: String(parkY), fnlDt: "", pkGubun: parkType, bujeGubun: "", oprDay: "", feeInfo: "", pkBascTime: "", pkAddTime: "", feeAdd: "", ftDayApplytime: "", payMtd: "", spclNote: "", currava: "", oprtFm: "")
+    func toParkItem() -> Park {
+        return Park(id: nil, emptySpace: String(parkEmpty), handicapSpace: String(handicapSpace), guNm: "", pkNam: parkName, mgntNum: "", doroAddr: parkAddress, jibunAddr: "", tponNum: parkPhone, pkFm: "", pkCnt: String(parkSpace), svcSrtTe: parkOperatingTime, svcEndTe: "", satSrtTe: "", satEndTe: "", hldSrtTe: "", hldEndTe: "", ldRtg: "", tenMin: parkBaseRate, ftDay: parkPerDayRate ?? "", ftMon: parkMonthlyRate ?? "", xCdnt: String(parkX), yCdnt: String(parkY), fnlDt: "", pkGubun: parkType, bujeGubun: "", oprDay: "", feeInfo: "", pkBascTime: "", pkAddTime: "", feeAdd: "", ftDayApplytime: "", payMtd: "", spclNote: "", currava: "", oprtFm: "")
     }
 }
 

--- a/CarPark/ViewControllers/BottomSheetParksViewController.swift
+++ b/CarPark/ViewControllers/BottomSheetParksViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class BottomSheetParksViewController: BaseViewController {
 
-    private var parks: [Item] = []
+    private var parks: [Park] = []
     private var isShowFavorite = true
     private var filterState: FilterParkHeaderView.State = .distance
     
@@ -153,7 +153,7 @@ extension BottomSheetParksViewController: FilterParkHeaderViewDelegate {
         tableView.reloadData()
         ParkDB.shared.$isShowParks
             .sink { [weak self] newParks in
-                self?.parks = newParks.map { $0.data }
+                self?.parks = newParks.map { $0.park }
                 self?.tableView.reloadData()
             }
             .store(in: &cancellable)
@@ -164,8 +164,8 @@ extension BottomSheetParksViewController: FilterParkHeaderViewDelegate {
         ParkDB.shared.$isShowParks
             .sink { [weak self] newParks in
                 self?.parks = newParks.sorted { lhs, rhs in
-                    Int(lhs.data.tenMin) ?? 0 < Int(rhs.data.tenMin) ?? 0
-                }.map { $0.data }
+                    Int(lhs.park.tenMin) ?? 0 < Int(rhs.park.tenMin) ?? 0
+                }.map { $0.park }
                 self?.tableView.reloadData()
             }
             .store(in: &cancellable)

--- a/CarPark/ViewControllers/CarParkInfoViewController.swift
+++ b/CarPark/ViewControllers/CarParkInfoViewController.swift
@@ -68,7 +68,7 @@ final class CarParkInfoViewController: BaseViewController {
         reviewTextField.delegate = self
         setUpTableView()
         bind()
-        setData(with: viewModel.marker.data)
+        setData(with: viewModel.marker.park)
         checkFavorite()
         addKeyboardNotification()
     }
@@ -96,7 +96,7 @@ final class CarParkInfoViewController: BaseViewController {
         ])
     }
     
-    private func setData(with item: Item) {
+    private func setData(with item: Park) {
         self.pkNamLabel.text = item.pkNam
         self.pkGubunLabel.text = item.pkGubun
         self.pkCntLabel.text = item.pkCnt + " 면"

--- a/CarPark/ViewControllers/ImageContentViewController.swift
+++ b/CarPark/ViewControllers/ImageContentViewController.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+final class ImageContentViewController: BaseViewController {
+    
+    let image: UIImage
+    
+    private lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.image = self.image
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    init(image: UIImage) {
+        self.image = image
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func configureHierarchy() {
+        self.view.addSubview(imageView)
+    }
+    
+    override func configureConstraints() {
+        NSLayoutConstraint.activate([
+            imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.heightAnchor.constraint(equalToConstant: 300),
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+}

--- a/CarPark/ViewControllers/ImagePageViewController.swift
+++ b/CarPark/ViewControllers/ImagePageViewController.swift
@@ -1,0 +1,78 @@
+import UIKit
+
+final class ImagePageViewController: BaseViewController {
+    
+    private lazy var pageVC: UIPageViewController = {
+        let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
+        pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        return pageViewController
+    }()
+    
+    var contentImages: [UIImage] = []
+    private var contentViewControllers: [UIViewController] = []
+    
+    private lazy var dismissBtn: UIButton = {
+        let view = UIButton()
+        view.setImage(UIImage(systemName: "xmark"), for: .normal)
+        view.tintColor = .black
+        view.addTarget(self, action: #selector(dismissVC), for: .touchUpInside)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configurePageViewController()
+    }
+    
+    override func configureHierarchy() {
+        self.view.addSubview(pageVC.view)
+        self.view.addSubview(dismissBtn)
+    }
+    
+    override func configureConstraints() {
+        NSLayoutConstraint.activate([
+            pageVC.view.topAnchor.constraint(equalTo: view.topAnchor, constant: 60),
+            pageVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            pageVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+          
+            dismissBtn.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            dismissBtn.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32),
+            dismissBtn.widthAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+    
+    private func configurePageViewController() {
+        contentImages
+           .forEach { image in
+               let vc = ImageContentViewController(image: image)
+               contentViewControllers.append(vc)
+           }
+        
+        pageVC.dataSource = self
+        addChild(pageVC)
+        pageVC.didMove(toParent: self)
+        pageVC.setViewControllers([contentViewControllers[0]], direction: .forward, animated: false)
+    }
+    
+    @objc func dismissVC() {
+        self.dismiss(animated: true)
+    }
+}
+
+extension ImagePageViewController: UIPageViewControllerDataSource {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let index = contentViewControllers.firstIndex(of: viewController) else { return nil }
+        var previousIndex = index - 1
+        if previousIndex < 0 { previousIndex = contentViewControllers.count - 1 }
+        return contentViewControllers[previousIndex]
+    }
+    
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let index = contentViewControllers.firstIndex(of: viewController) else { return nil }
+        let nextIndex = (index + 1) % contentViewControllers.count
+        return contentViewControllers[nextIndex]
+    }
+}

--- a/CarPark/ViewControllers/LoginViewController.swift
+++ b/CarPark/ViewControllers/LoginViewController.swift
@@ -42,6 +42,7 @@ final class LoginViewController: UIViewController {
     private func checkLogin() {
 // 로그인 skip
 //        if UserDefault.shared.checkLoggedIn() {
+            UserDefault.shared.setLogin(id: "test", nickname: "테스트유저")
             self.navigationController?.popToRootViewController(animated: true)
             self.navigationController?.pushViewController(ViewController(), animated: false)
 //        }

--- a/CarPark/ViewControllers/Main/ViewController+CLLocationDelegate.swift
+++ b/CarPark/ViewControllers/Main/ViewController+CLLocationDelegate.swift
@@ -16,7 +16,7 @@ extension ViewController: CLLocationManagerDelegate {
         cameraUpdate.animation = .easeIn
         
         if manager.authorizationStatus == .authorizedAlways || manager.authorizationStatus == .authorizedWhenInUse {
-            setParks()
+            setPartnerParks()
             setMarker()
             getClusterParks()
         }

--- a/CarPark/ViewControllers/Main/ViewController+CameraDelegate.swift
+++ b/CarPark/ViewControllers/Main/ViewController+CameraDelegate.swift
@@ -4,17 +4,13 @@ import NMapsMap
 extension ViewController: NMFMapViewCameraDelegate {
 
     func mapViewCameraIdle(_ mapView: NMFMapView) {
-        let allMarkers = ParkDB.shared.allMarkers
-        
         if driving {
-            allMarkers.forEach { item in
+            self.allMarkers.forEach { item in
                 if item.drivingMarker { item.hidden = false }
                 else { item.hidden = true }
             }
             return
         }
-//        let markers = ParkDB.shared.markers
-//        var partenerMarkers: [ParkMarker] = []
         
         let projection = mapView.projection
         
@@ -23,11 +19,8 @@ extension ViewController: NMFMapViewCameraDelegate {
         
         ParkDB.shared.resetShowingParks()
         
-        allMarkers.forEach { item in
-            item.vc = self
-            item.mapView = self.NM.mapView
-            
-            if let emptySpace = item.data.emptySpace, Int(emptySpace)! != 0 {
+        self.allMarkers.forEach { item in
+            if let emptySpace = item.park.emptySpace, Int(emptySpace)! != 0 {
                 let infoWindow = NMFInfoWindow()
                 infoWindow.dataSource = CustomInfoWindowDataSource()
                 infoWindow.open(with: item)
@@ -40,7 +33,7 @@ extension ViewController: NMFMapViewCameraDelegate {
                 if mapView.cameraPosition.zoom <= 11.5 {
                     
                     for clusterPark in clusterParks {
-                        if item.data == clusterPark.0 {
+                        if item.park == clusterPark.0 {
                             
                             let infoWindow = NMFInfoWindow()
                             let dataSource = NMFInfoWindowDefaultTextSource.data()
@@ -59,7 +52,7 @@ extension ViewController: NMFMapViewCameraDelegate {
                 else {
                     item.hidden = false
                     
-                    if item.data.emptySpace == nil {
+                    if item.park.emptySpace == nil {
                         item.infoWindow?.close()
                     }
                 }
@@ -72,7 +65,7 @@ extension ViewController: NMFMapViewCameraDelegate {
         let current = CLLocationCoordinate2D(latitude: self.locationManager.location?.coordinate.latitude ?? -1, longitude: self.locationManager.location?.coordinate.longitude ?? -1)
         
         ParkDB.shared.setShowingParks(parkMarker: allMarkers.filter { $0.hidden == false }.sorted(by: { lhs, rhs in
-            current.distance(from: CLLocationCoordinate2D(latitude: Double(lhs.data.yCdnt) ?? -1, longitude: Double(lhs.data.xCdnt) ?? -1)) < current.distance(from: CLLocationCoordinate2D(latitude: Double(rhs.data.yCdnt) ?? -1, longitude: Double(rhs.data.xCdnt) ?? -1))
+            current.distance(from: CLLocationCoordinate2D(latitude: Double(lhs.park.yCdnt) ?? -1, longitude: Double(lhs.park.xCdnt) ?? -1)) < current.distance(from: CLLocationCoordinate2D(latitude: Double(rhs.park.yCdnt) ?? -1, longitude: Double(rhs.park.xCdnt) ?? -1))
             
         }))
 //

--- a/CarPark/ViewControllers/Main/ViewController.swift
+++ b/CarPark/ViewControllers/Main/ViewController.swift
@@ -5,9 +5,9 @@ final class ViewController: UIViewController {
     
     let locationManager = CLLocationManager()
     
-    private(set) var parks: [Item] = []
-    private(set) var clusterParks: [(Item, Int)] = []
-    private(set) var partnerParks: [Item] = []
+    private(set) var clusterParks: [(Park, Int)] = []
+    private(set) var partnerParks: [Park] = []
+    private(set) var allMarkers: [ParkMarker] = []
     
     var driving: Bool = false
     
@@ -126,7 +126,7 @@ final class ViewController: UIViewController {
         super.viewDidLoad()
         navigationController?.isNavigationBarHidden = true
         setLocation(locationManager: locationManager)
-        setParks()
+        setPartnerParks()
         setMarker()
         getClusterParks()
         configureHierarchy()
@@ -230,16 +230,23 @@ extension ViewController {
 
 // MARK: 데이터를 설정하는 함수 extension
 extension ViewController {
-    func setParks() {
-        parks = ParkDB.shared.data
+    func setPartnerParks() {
         partnerParks = ParkDB.shared.partnerParks
     }
     
     func setMarker() {
         ParkDB.shared.setMarker(vc: self)
+        self.allMarkers = ParkDB.shared.allMarkers
     }
     
     func getClusterParks() {
         clusterParks = ParkDB.shared.clusterItems()
+    }
+    
+    func appendParkMarker(marker: ParkMarker) {
+        marker.vc = self
+        marker.mapView = self.NM.mapView
+        marker.hidden = false
+        self.allMarkers.append(marker)
     }
 }

--- a/CarPark/ViewControllers/SearchResultViewController.swift
+++ b/CarPark/ViewControllers/SearchResultViewController.swift
@@ -3,8 +3,8 @@ import NMapsMap
 
 final class SearchResultViewController: UIViewController {
     
-    var parks: [Item]
-    var recommendParks: [Item]
+    var parks: [Park]
+    var recommendParks: [Park]
     
     let NM: NMFNaverMapView
     
@@ -18,7 +18,7 @@ final class SearchResultViewController: UIViewController {
         return view
     }()
     
-    init(parks: [Item], recommendParks: [Item], NM: NMFNaverMapView) {
+    init(parks: [Park], recommendParks: [Park], NM: NMFNaverMapView) {
         self.parks = parks
         self.recommendParks = recommendParks
         self.NM = NM

--- a/CarPark/ViewControllers/SubmitParkVCs/SubimtParkViewController3.swift
+++ b/CarPark/ViewControllers/SubmitParkVCs/SubimtParkViewController3.swift
@@ -164,12 +164,12 @@ final class SubimtParkViewController3: BaseViewController {
     
     @objc func submitPark() {
         let nickName = UserDefault.shared.getNickname()
-        let userPark = UserPark(userNickname: nickName, description: descriptionTextView.text ?? "", lat: self.lat, lng: self.lng, startTime: datePicker.date.toString(type: .monthAndDate), endTime: datePicker2.date.toString(type: .monthAndDate))
+        let userPark = UserPark(userNickname: nickName, description: descriptionTextView.text ?? "", lat: self.lat, lng: self.lng, startTime: datePicker.date.toString(type: .monthAndDayAndHourAndMinute), endTime: datePicker2.date.toString(type: .monthAndDayAndHourAndMinute))
         
         _ = navigationController?.viewControllers.first(where: { vc in
             guard let vc = vc as? ViewController else { return false }
             let newMarker = ParkMarker(userPark: userPark, vc)
-            newMarker.setTouchEvent(vc: vc, data: userPark)
+            newMarker.setTouchEvent(vc: vc, data: userPark, images: self.images)
             vc.appendParkMarker(marker: newMarker)
             self.navigationController?.popToViewController(vc, animated: true)
             

--- a/CarPark/ViewControllers/SubmitParkVCs/SubimtParkViewController3.swift
+++ b/CarPark/ViewControllers/SubmitParkVCs/SubimtParkViewController3.swift
@@ -163,14 +163,14 @@ final class SubimtParkViewController3: BaseViewController {
     }
     
     @objc func submitPark() {
-        print("submit")
-        // viewmodel? 로 마커 하나 생성하고 사진 정보 정도 보여주는 new marker ?를
-        // 만들어야하지않을까 ?
-        
+        let nickName = UserDefault.shared.getNickname()
+        let userPark = UserPark(userNickname: nickName, description: descriptionTextView.text ?? "", lat: self.lat, lng: self.lng, startTime: datePicker.date.toString(type: .monthAndDate), endTime: datePicker2.date.toString(type: .monthAndDate))
         
         _ = navigationController?.viewControllers.first(where: { vc in
             guard let vc = vc as? ViewController else { return false }
-            
+            let newMarker = ParkMarker(userPark: userPark, vc)
+            newMarker.setTouchEvent(vc: vc, data: userPark)
+            vc.appendParkMarker(marker: newMarker)
             self.navigationController?.popToViewController(vc, animated: true)
             
             return true

--- a/CarPark/ViewControllers/SubmitParkVCs/SubmitParkViewController.swift
+++ b/CarPark/ViewControllers/SubmitParkVCs/SubmitParkViewController.swift
@@ -91,8 +91,6 @@ extension SubmitParkViewController: PHPickerViewControllerDelegate {
                                 let nextSumbitVC = SubmitParkViewController2(chooseImages: self?.chooseImages ?? [])
                                 
                                 self?.navigationController?.pushViewController(nextSumbitVC, animated: true)
-                                
-//                                self?.show(nextSumbitVC, sender: nil)
                             }
                         }
                     }

--- a/CarPark/ViewControllers/UserCarParkInfoViewController.swift
+++ b/CarPark/ViewControllers/UserCarParkInfoViewController.swift
@@ -1,0 +1,161 @@
+import UIKit
+
+final class UserCarParkInfoViewController: BaseViewController {
+    
+    private let userParkData: UserPark
+    private let images: [UIImage]
+    
+    private lazy var mainStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.alignment = .leading
+        view.distribution = .fill
+        view.spacing = 20
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let view = UILabel()
+        view.text = userParkData.userNickname + "님의 공유주차장"
+        view.font = .systemFont(ofSize: 18, weight: .semibold)
+        
+        return view
+    }()
+    
+    private lazy var imageScrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        return view
+    }()
+    
+    private lazy var imageStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.alignment = .center
+        view.distribution = .fill
+        view.spacing = 15
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private lazy var timeLabel: UILabel = {
+        let view = UILabel()
+        view.text = userParkData.startTime + " ~ " + userParkData.endTime
+        view.font = .systemFont(ofSize: 14, weight: .regular)
+        
+        return view
+    }()
+    
+    private lazy var descriptionLabel: UILabel = {
+        let view = UILabel()
+        view.numberOfLines = 0
+        view.text = userParkData.description
+        view.font = .systemFont(ofSize: 14, weight: .regular)
+        view.translatesAutoresizingMaskIntoConstraints = false
+    
+        return view
+    }()
+    
+    private lazy var messageBtn: UIButton = {
+        let view = UIButton()
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular)
+        let image = UIImage(systemName: "ellipsis.message", withConfiguration: imageConfig)
+        
+        view.setImage(image, for: .normal)
+        
+        view.setTitleColor(.white, for: .focused)
+        view.tintColor = .white
+        view.backgroundColor = .orange
+        
+        view.layer.cornerRadius = 22
+        
+        view.clipsToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    init(userParkData: UserPark, images: [UIImage]) {
+        self.userParkData = userParkData
+        self.images = images
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
+    
+    override func configureHierarchy() {
+        view.addSubview(mainStackView)
+        mainStackView.addArrangedSubview(titleLabel)
+        mainStackView.addArrangedSubview(DividerView())
+        
+        for i in 0..<images.count {
+            imageStackView.addArrangedSubview(confiureImageView(image: images[i], tag: i))
+        }
+        imageScrollView.addSubview(imageStackView)
+        mainStackView.addArrangedSubview(imageScrollView)
+        
+        mainStackView.addArrangedSubview(DividerView())
+        mainStackView.addArrangedSubview(timeLabel)
+        mainStackView.addArrangedSubview(DividerView())
+        mainStackView.addArrangedSubview(descriptionLabel)
+        
+        view.addSubview(messageBtn)
+    }
+    
+    override func configureConstraints() {
+        NSLayoutConstraint.activate([
+            mainStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32),
+            mainStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            mainStackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            
+            imageScrollView.heightAnchor.constraint(equalToConstant: 110),
+            imageScrollView.widthAnchor.constraint(equalToConstant: view.bounds.width),
+            
+            imageStackView.topAnchor.constraint(equalTo: imageScrollView.topAnchor),
+            imageStackView.leadingAnchor.constraint(equalTo: imageScrollView.leadingAnchor),
+            imageStackView.trailingAnchor.constraint(equalTo: imageScrollView.trailingAnchor),
+            imageStackView.bottomAnchor.constraint(equalTo: imageScrollView.bottomAnchor),
+            
+            descriptionLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
+            
+            messageBtn.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
+            messageBtn.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor,constant: -32),
+            messageBtn.heightAnchor.constraint(equalToConstant: 44),
+            messageBtn.widthAnchor.constraint(equalToConstant: 44),
+        ])
+    }
+    
+    private func confiureImageView(image: UIImage, tag: Int) -> UIImageView {
+        let thumbnail = image.preparingThumbnail(of: CGSize(width: 100, height: 100))
+        
+        let view = UIImageView(image: thumbnail)
+        view.tag = tag
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(showOriginalImage(_:)))
+        view.addGestureRecognizer(tapGesture)
+        view.isUserInteractionEnabled = true
+
+        return view
+    }
+    
+    @objc func showOriginalImage(_ gesture: UITapGestureRecognizer) {
+        let showImageVC = ImagePageViewController()
+        showImageVC.contentImages = images
+        showImageVC.modalPresentationStyle = .fullScreen
+        
+        present(showImageVC, animated: true)
+    }
+}
+

--- a/CarPark/ViewModels/CarParkInfoViewModel.swift
+++ b/CarPark/ViewModels/CarParkInfoViewModel.swift
@@ -30,22 +30,22 @@ final class CarParkInfoViewModel: NSObject, ObservableObject {
     }
     
     func checkFavorite() -> Bool {
-        UserDefault.shared.checkFavorite(with: self.marker.data)
+        UserDefault.shared.checkFavorite(with: self.marker.park)
     }
     
     func tappedFavoriteAction() {
-        UserDefault.shared.setFavoriteParks(item: self.marker.data)
+        UserDefault.shared.setFavoriteParks(item: self.marker.park)
     }
     
     func getDriving() {
-        delegate?.getDriving(goalLng: marker.data.xCdnt, goalLat: marker.data.yCdnt, goalLocation: marker.data.pkNam, marker: marker)
+        delegate?.getDriving(goalLng: marker.park.xCdnt, goalLat: marker.park.yCdnt, goalLocation: marker.park.pkNam, marker: marker)
     }
     
     func postReview(with review: String) {
         let parameter: [String: Any] = [
             "user_Name" : UserDefault.shared.getNickname(),
             "review" : review,
-            "park_Name" : self.marker.data.pkNam
+            "park_Name" : self.marker.park.pkNam
         ]
 
         NetworkManager.shared.request(with: APIConstants.saveReviewURL, method: .post, parameter: parameter) { result in
@@ -60,7 +60,7 @@ final class CarParkInfoViewModel: NSObject, ObservableObject {
     
     // MARK: 서버에서 리뷰를 가져오는 함수
     private func fetchReview() {
-        let urlParkName = marker.data.pkNam.components(separatedBy: " ").joined()
+        let urlParkName = marker.park.pkNam.components(separatedBy: " ").joined()
         let encodeURL = (APIConstants.fetchReviewURL + urlParkName).encodeUrl()!
         
         NetworkManager.shared.request(with: encodeURL, method: .get, type: ParkReviewStatus.self) { result in

--- a/CarPark/Views/CustomInfoWindowDataSource.swift
+++ b/CarPark/Views/CustomInfoWindowDataSource.swift
@@ -9,9 +9,9 @@ final class CustomInfoWindowDataSource: NSObject, NMFOverlayImageDataSource {
         
         // MARK: PartnerMarker로 바꾼 다음 빈자리를 넣기
         if let marker = infoWindow.marker as? ParkMarker {
-            guard marker.data.emptySpace != "0" else { return UIView() }
-            rootView.textLabel.text = ": \(marker.data.emptySpace ?? "")"
-            rootView.textLabel2.text = ": \(marker.data.handicapSpace ?? "")"
+            guard marker.park.emptySpace != "0" else { return UIView() }
+            rootView.textLabel.text = ": \(marker.park.emptySpace ?? "")"
+            rootView.textLabel2.text = ": \(marker.park.handicapSpace ?? "")"
         }
         
 //        rootView.textLabel.sizeToFit()

--- a/CarPark/Views/ParkMarker.swift
+++ b/CarPark/Views/ParkMarker.swift
@@ -74,14 +74,14 @@ final class ParkMarker: NMFMarker {
         }
     }
     
-    func setTouchEvent(vc: ViewController, data: UserPark) {
+    func setTouchEvent(vc: ViewController, data: UserPark, images: [UIImage]) {
         self.touchHandler = { (overlay: NMFOverlay) -> Bool in
             if self.drivingMarker { return false }
             
-            let sheetVC: UserCarParkInfoViewController = UserCarParkInfoViewController()
+            let sheetVC: UserCarParkInfoViewController = UserCarParkInfoViewController(userParkData: data, images: images)
             
             if let presentationSheetVC = sheetVC.presentationController as? UISheetPresentationController {
-                presentationSheetVC.detents = [.medium(), .large()]
+                presentationSheetVC.detents = [.medium(), .medium()]
                 presentationSheetVC.prefersGrabberVisible = true
                 self.vc?.present(sheetVC, animated: true)
             }

--- a/CarPark/Views/ParkMarker.swift
+++ b/CarPark/Views/ParkMarker.swift
@@ -6,24 +6,30 @@ final class ParkMarker: NMFMarker {
     
     var didTap: (() -> Bool)?
 
-    let data: Item
+    let park: Park
+    let userPark: UserPark
+    
     var vc: ViewController?
     var drivingMarker: Bool = false
     
-    init(data: Item, _ vc: ViewController? = nil) {
-        self.data = data
-        self.vc = vc
-        super.init()
-        
-        if data.yCdnt == "-" { return }
-        
+    private func configureMarker() {
         self.width = 30
         self.height = 35
         self.iconPerspectiveEnabled = true
         self.iconImage = NMFOverlayImage(name: "marker_normal")
         self.hidden = true
+    }
+    
+    init(park: Park, _ vc: ViewController? = nil) {
+        self.park = park
+        self.vc = vc
+        self.userPark = UserPark.empty()
+        super.init()
         
-        if let emptySpace = Int(data.emptySpace ?? "") {
+        if park.yCdnt == "-" { return }
+        configureMarker()
+        
+        if let emptySpace = Int(park.emptySpace ?? "") {
             self.width = 35
             self.height = 40
             self.hidden = false
@@ -34,10 +40,22 @@ final class ParkMarker: NMFMarker {
             }
         }
         
-        self.position = NMGLatLng(lat: Double(data.yCdnt) ?? -1, lng: Double(data.xCdnt) ?? -1)
+        self.position = NMGLatLng(lat: Double(park.yCdnt) ?? -1, lng: Double(park.xCdnt) ?? -1)
     }
     
-    func setTouchEvent(vc: ViewController) {
+    init(userPark: UserPark, _ vc: ViewController? = nil) {
+        self.userPark = userPark
+        self.vc = vc
+        self.park = Park.empty()
+        
+        super.init()
+        
+        configureMarker()
+        self.iconImage = NMFOverlayImage(name: "marker_available")
+        self.position = NMGLatLng(lat: userPark.lat, lng: userPark.lng)
+    }
+    
+    func setTouchEvent(vc: ViewController, data: Park) {
         self.touchHandler = { (overlay: NMFOverlay) -> Bool in
             if self.drivingMarker { return false }
             
@@ -49,6 +67,22 @@ final class ParkMarker: NMFMarker {
                 presentationSheetVC.detents = [.medium(), .large()]
                 presentationSheetVC.prefersGrabberVisible = true
                 sheetVC.viewModel.delegate = vc
+                self.vc?.present(sheetVC, animated: true)
+            }
+            
+            return true
+        }
+    }
+    
+    func setTouchEvent(vc: ViewController, data: UserPark) {
+        self.touchHandler = { (overlay: NMFOverlay) -> Bool in
+            if self.drivingMarker { return false }
+            
+            let sheetVC: UserCarParkInfoViewController = UserCarParkInfoViewController()
+            
+            if let presentationSheetVC = sheetVC.presentationController as? UISheetPresentationController {
+                presentationSheetVC.detents = [.medium(), .large()]
+                presentationSheetVC.prefersGrabberVisible = true
                 self.vc?.present(sheetVC, animated: true)
             }
             

--- a/CarPark/Views/ParkTitleCell.swift
+++ b/CarPark/Views/ParkTitleCell.swift
@@ -44,13 +44,13 @@ final class ParkTitleCell: UITableViewCell {
         self.titleLabel.text = text
     }
     
-    func setTapAction(_ vc: ViewController, _ item: Item) {
+    func setTapAction(_ vc: ViewController, _ item: Park) {
         didTap = { [weak vc] in
             guard let vc else { return }
             if let lng = Double(item.xCdnt), let lat = Double(item.yCdnt) {
                 vc.NM.mapView.moveCamera(NMFCameraUpdate(position: NMFCameraPosition(NMGLatLng(lat: lat, lng: lng), zoom: 15)))
                 
-                guard let marker = ParkDB.shared.allMarkers.filter({ $0.data.pkNam == item.pkNam }).first else { return }
+                guard let marker = ParkDB.shared.allMarkers.filter({ $0.park.pkNam == item.pkNam }).first else { return }
                 
                 let sheetVC: CarParkInfoViewController = UIStoryboard(name: "CarParkInfoView", bundle: nil).instantiateViewController(identifier: "CarParkInfoView") { coder in
                     let vc = CarParkInfoViewController(viewModel: CarParkInfoViewModel(marker: marker), coder: coder)


### PR DESCRIPTION
### 추가사항

- 유저가 등록한 마커를 따로 구현하였습니다.
- 유저가 등록한 공유 주차장을 확인하는 뷰 컨트롤러를 구현하였습니다.
    - 내부 사진을 썸네일로 두고, 썸네일을 클릭할 시 원래 사진을 보여주는 페이지 뷰 컨트롤러를 구현하였습니다
- 유저가 등록한 주차장의 데이터 모델(`UserPark`)을 추가하였습니다

### 변경사항

- 기존의 주차장 데이터 타입 이름인 `Item` 을 `Park`로 변경하였습니다. 
- 공공 주차장을 표시하는 마커를 유저가 등록한 공유 주차장도 표시할 수 있게 수정하였습니다.

### 고민사항

기존의 마커는 공공 주차장의 데이터를 들고있었는데, 유저의 데이터가 들어오면 데이터에 맞게 속성 값을 설정하는 형태로 구현을 수정하였습니다. 생성자 오버로딩과 내부 터치 이벤트를 설정하는 함수를 오버로딩하여 구현하였습니다.

내부 마커가 데이터에 따라서 두 가지 형태로 나타나기 때문에 아예 분리하는게 낫나 싶은데 크기 속성이나 보여지는 속성 같은 공통된 속성도 있어서 지금 방식대로 구현하는것도 괜찮은거 같은 생각이 드는데 뭐가 더 괜찮은지는 아직 고민중에 있슴니다.. 지금 생각나는 다른 방법은 공통된 속성들을 묶어서 상위 클래스로 두고 상속하는 방식도 좋을듯함니다..! 좀 더 마커의 종류가 늘어나면 이 코드는 수정을 해야할 필요성이 있을듯합니다.
